### PR TITLE
Use GitHub Actions as CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        smalltalk: [Squeak64-trunk, Squeak64-5.3, Squeak64-5.2]
+    name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hpi-swa/setup-smalltalkCI@v1
+        with:
+          smalltalk-image: ${{ matrix.smalltalk }}
+      - run: smalltalkci -s ${{ matrix.smalltalk }}
+        timeout-minutes: 15
+        env:
+          # for uploading coverage reports
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,13 @@
+name: PR
+
+on: [pull_request]
+
+jobs:
+  assign-author:
+    name: Assign author
+    if: github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: samspills/assign-pr-to-author@v1.0
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: smalltalk
-sudo: false
-smalltalk:
-  - Squeak64-trunk
-  - Squeak64-5.3
-  - Squeak64-5.2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-AutoTDD with Travis-CI Support
-===================
-[![Build Status](https://travis-ci.org/hpi-swa-teaching/AutoTDD.svg)](https://travis-ci.org/hpi-swa-teaching/AutoTDD) [![Coverage Status](https://coveralls.io/repos/github/hpi-swa-teaching/AutoTDD/badge.svg?branch=dev)](https://coveralls.io/github/hpi-swa-teaching/AutoTDD?branch=dev)
+# AutoTDD with GitHub Actions & Travis-CI Support
+
+[![CI](https://github.com/hpi-swa-teaching/AutoTDD/workflows/CI/badge.svg?branch=dev)](https://github.com/hpi-swa-teaching/AutoTDD/actions)
+[![Coverage Status](https://coveralls.io/repos/github/hpi-swa-teaching/AutoTDD/badge.svg?branch=dev)](https://coveralls.io/github/hpi-swa-teaching/AutoTDD?branch=dev)
 
 ## About
 AutoTDD is an automated testing tool for continuously monitoring the test state of your project. You tests will be automatically executed when a method in your project changes. When a test fails, you will get instant feedback about what went wrong. It also displays current Travis build results.


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
Closes: #59 

<!-- Please summarize your changes: -->
Instead of using Travis CI the repo now uses GitHub Actions as CI.

Additionally I added a workflow that will assign the creator of a PR as author (for convenience)